### PR TITLE
feat: implement role-based access control and scanner check-in logic (Issue #4)

### DIFF
--- a/packages/contracts/contracts/TicketNFT.sol
+++ b/packages/contracts/contracts/TicketNFT.sol
@@ -76,12 +76,18 @@ contract TicketNFT is
     emit TicketMinted(tokenId, eventId, to, _tokenURI);
 }
 
-    function checkInTicket(uint256 tokenId) public onlyRole(SCANNER_ROLE) {
-        require(tokenEventId[tokenId] != 0, "Ticket does not exist");
+    function checkInTicket(uint256 tokenId) public {
+        require(
+            hasRole(SCANNER_ROLE, msg.sender) || 
+            hasRole(ORGANIZER_ROLE, msg.sender) ||
+            hasRole(DEFAULT_ADMIN_ROLE, msg.sender),
+            "Not authorized to check in"
+        );
+
+        ownerOf(tokenId); 
+
         require(!isUsed[tokenId], "Ticket already used");
-
         isUsed[tokenId] = true;
-
         emit TicketCheckedIn(tokenId, msg.sender);
     }
 

--- a/packages/contracts/contracts/TicketNFT.sol
+++ b/packages/contracts/contracts/TicketNFT.sol
@@ -27,12 +27,14 @@ contract TicketNFT is
 
     // Events
     event TicketMinted(uint256 indexed tokenId, uint256 indexed eventId, address indexed to, string tokenURI);
+    event TicketCheckedIn(uint256 indexed tokenId, address indexed scanner);
 
     // Roles
     bytes32 public constant ORGANIZER_ROLE = keccak256("ORGANIZER_ROLE");
     bytes32 public constant SCANNER_ROLE = keccak256("SCANNER_ROLE");
 
     // Constructor to disable initializers for the implementation contract
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
     }
@@ -73,6 +75,15 @@ contract TicketNFT is
 
     emit TicketMinted(tokenId, eventId, to, _tokenURI);
 }
+
+    function checkInTicket(uint256 tokenId) public onlyRole(SCANNER_ROLE) {
+        require(tokenEventId[tokenId] != 0, "Ticket does not exist");
+        require(!isUsed[tokenId], "Ticket already used");
+
+        isUsed[tokenId] = true;
+
+        emit TicketCheckedIn(tokenId, msg.sender);
+    }
 
     // Overrides functions
     function tokenURI(uint256 tokenId)

--- a/packages/contracts/test/AccessControl.test.ts
+++ b/packages/contracts/test/AccessControl.test.ts
@@ -44,10 +44,42 @@ describe("TicketNFT - Role-Based Access Control", function () {
 
         await ticketNFT.connect(organizer).mintTicket(admin.address, "ipfs://test-uri", 1, 0);
 
-        await expect(ticketNFT.connect(hacker).checkInTicket(0)).to.be.revertedWithCustomError(ticketNFT, "AccessControlUnauthorizedAccount");
+        await expect(ticketNFT.connect(hacker).checkInTicket(0)).to.be.revertedWith("Not authorized to check in");
 
         await expect(ticketNFT.connect(scanner).checkInTicket(0)).to.emit(ticketNFT, "TicketCheckedIn").withArgs(0, scanner.address);
 
         expect(await ticketNFT.isUsed(0)).to.be.true;
+    });
+
+    it("Should allow Admin and Organizer to check in tickets", async function () {
+        const ORGANIZER_ROLE = ethers.id("ORGANIZER_ROLE");
+        await ticketNFT.grantRole(ORGANIZER_ROLE, organizer.address);
+        await ticketNFT.connect(organizer).mintTicket(admin.address, "ipfs://test1", 1, 0);
+        await ticketNFT.connect(organizer).mintTicket(admin.address, "ipfs://test2", 1, 0);
+
+        await expect(ticketNFT.connect(organizer).checkInTicket(0))
+        .to.emit(ticketNFT, "TicketCheckedIn")
+        .withArgs(0, organizer.address);
+        await expect(ticketNFT.connect(admin).checkInTicket(1))
+        .to.emit(ticketNFT, "TicketCheckedIn")
+        .withArgs(1, admin.address);
+  });
+
+  it("Should prevent double check-ins", async function () {
+        const ORGANIZER_ROLE = ethers.id("ORGANIZER_ROLE");
+        await ticketNFT.grantRole(ORGANIZER_ROLE, organizer.address);
+        
+        await ticketNFT.connect(organizer).mintTicket(admin.address, "ipfs://test", 1, 0);
+        
+        await ticketNFT.connect(organizer).checkInTicket(0);
+        await expect(ticketNFT.connect(organizer).checkInTicket(0))
+        .to.be.revertedWith("Ticket already used");
+  });
+
+  it("Should revert when checking in a non-existent ticket", async function () {
+        const SCANNER_ROLE = ethers.id("SCANNER_ROLE");
+        await ticketNFT.grantRole(SCANNER_ROLE, scanner.address);
+        await expect(ticketNFT.connect(scanner).checkInTicket(999))
+        .to.be.reverted;
     });
 });

--- a/packages/contracts/test/AccessControl.test.ts
+++ b/packages/contracts/test/AccessControl.test.ts
@@ -1,0 +1,53 @@
+import { expect } from "chai";
+import { ethers, upgrades } from "hardhat";
+
+describe("TicketNFT - Role-Based Access Control", function () {
+    let ticketNFT: any;
+    let admin: any, organizer: any, scanner: any, hacker: any;
+
+    beforeEach(async function () {
+        [admin, organizer, scanner, hacker] = await ethers.getSigners();
+        const TicketNFTFactory = await ethers.getContractFactory("TicketNFT");
+        ticketNFT = await upgrades.deployProxy(TicketNFTFactory, [admin.address], { kind: "uups" });
+    });
+
+    it("Should have correctly defined roles", async function () {
+        const ORGANIZER_ROLE = ethers.id("ORGANIZER_ROLE");
+        const SCANNER_ROLE = ethers.id("SCANNER_ROLE");
+    
+        expect(await ticketNFT.ORGANIZER_ROLE()).to.equal(ORGANIZER_ROLE);
+        expect(await ticketNFT.SCANNER_ROLE()).to.equal(SCANNER_ROLE);
+    });
+
+    it("Should allow admin to grant roles", async function () {
+        const ORGANIZER_ROLE = await ticketNFT.ORGANIZER_ROLE();
+        await ticketNFT.grantRole(ORGANIZER_ROLE, organizer.address);
+        expect(await ticketNFT.hasRole(ORGANIZER_ROLE, organizer.address)).to.be.true;
+    });
+
+    it("Should restrict minting to organizers only and reject hackers", async function () {
+        const ORGANIZER_ROLE = await ticketNFT.ORGANIZER_ROLE();
+        await ticketNFT.grantRole(ORGANIZER_ROLE, organizer.address);
+
+        
+        await ticketNFT.connect(organizer).mintTicket(admin.address, "ipfs://test-uri", 1, 0);
+
+        await expect(ticketNFT.connect(hacker).mintTicket(hacker.address, "ipfs://hacker-uri", 1, 0)).to.be.revertedWithCustomError(ticketNFT, "AccessControlUnauthorizedAccount");
+    });
+
+    it("Should restrict check-in to scanners and reject hackers", async function () {
+        const ORGANIZER_ROLE = await ticketNFT.ORGANIZER_ROLE();
+        const SCANNER_ROLE = await ticketNFT.SCANNER_ROLE();
+
+        await ticketNFT.grantRole(ORGANIZER_ROLE, organizer.address);
+        await ticketNFT.grantRole(SCANNER_ROLE, scanner.address);
+
+        await ticketNFT.connect(organizer).mintTicket(admin.address, "ipfs://test-uri", 1, 0);
+
+        await expect(ticketNFT.connect(hacker).checkInTicket(0)).to.be.revertedWithCustomError(ticketNFT, "AccessControlUnauthorizedAccount");
+
+        await expect(ticketNFT.connect(scanner).checkInTicket(0)).to.emit(ticketNFT, "TicketCheckedIn").withArgs(0, scanner.address);
+
+        expect(await ticketNFT.isUsed(0)).to.be.true;
+    });
+});


### PR DESCRIPTION
Closes #4
Resolves #15, #16, #17, #18, #19, #61

This PR builds directly on top of the newly merged core NFT logic (Issue #2) and adds the required security layer.

**Key Changes:**
* **Access Control:** Implemented OpenZeppelin's `AccessControlUpgradeable`.
* **Scanner Logic:** Added the `checkInTicket(uint256 tokenId)` function to mark tickets as used.
  * *Update:* As per the design doc, access is granted to `SCANNER_ROLE`, `ORGANIZER_ROLE`, and `DEFAULT_ADMIN_ROLE`.
  * *Update:* Fixed the existence verification bug by leveraging OpenZeppelin's `ownerOf()` instead of checking `eventId != 0`.
* **Unit Tests:** Expanded test coverage to verify that:
  * Admins, Organizers, and Scanners can check in.
  * Double check-ins are prevented.
  * Checking in non-existent tickets reverts correctly.
  * Unauthorized accounts (hackers) revert when attempting to check in.