### PR TITLE
feat: add isValidTicket view function for frontend validation

### DIFF
--- a/packages/contracts/contracts/TicketNFT.sol
+++ b/packages/contracts/contracts/TicketNFT.sol
@@ -91,6 +91,10 @@ contract TicketNFT is
         emit TicketCheckedIn(tokenId, msg.sender);
     }
 
+    function isValidTicket(uint256 tokenId) public view returns (bool) {
+        return _ownerOf(tokenId) != address(0) && !isUsed[tokenId];
+    }
+
     // Overrides functions
     function tokenURI(uint256 tokenId)
         public

--- a/packages/contracts/test/AccessControl.test.ts
+++ b/packages/contracts/test/AccessControl.test.ts
@@ -81,5 +81,18 @@ describe("TicketNFT - Role-Based Access Control", function () {
         await ticketNFT.grantRole(SCANNER_ROLE, scanner.address);
         await expect(ticketNFT.connect(scanner).checkInTicket(999))
         .to.be.reverted;
-    });
+  });
+
+  it("Should correctly report ticket validity (isValidTicket)", async function () {
+        const ORGANIZER_ROLE = ethers.id("ORGANIZER_ROLE");
+        await ticketNFT.grantRole(ORGANIZER_ROLE, organizer.address);
+
+        expect(await ticketNFT.isValidTicket(999)).to.be.false;
+
+        await ticketNFT.connect(organizer).mintTicket(admin.address, "ipfs://test", 1, 0);
+        expect(await ticketNFT.isValidTicket(0)).to.be.true;
+
+        await ticketNFT.connect(organizer).checkInTicket(0);
+        expect(await ticketNFT.isValidTicket(0)).to.be.false;
+  });
 });


### PR DESCRIPTION
Closes #5
Resolves #21

Following up on the check-in logic, this PR adds a dedicated `isValidTicket(uint256 tokenId)` view function.

As requested, instead of forcing the frontend or scanner to handle a revert from `ownerOf()` when a ticket doesn't exist, this function returns a clean boolean. It verifies BOTH:
1. That the ticket exists (has been minted).
2. That the ticket has not been used yet (`!isUsed`).

Added test coverage to ensure it correctly returns `false` for unminted tickets, `true` for valid tickets, and `false` after a check-in.

Please note that the other sub-issues attached to Issue #5 (#62 permanent used-state, #64 ticket existence check, and #65 double check-in prevention) were already implemented and merged in the previous RBAC PR.