### PR TITLE
feat: implement batch minting (Issue #69)

### DIFF
--- a/packages/contracts/contracts/TicketNFT.sol
+++ b/packages/contracts/contracts/TicketNFT.sol
@@ -56,25 +56,56 @@ contract TicketNFT is
     {}
 
     function mintTicket(
-    address to,
-    string memory _tokenURI,
-    uint256 eventId,
-    uint256 maxPrice
-) public onlyRole(ORGANIZER_ROLE) {
-    uint256 tokenId = tokenIdCounter;
-    tokenIdCounter++;
+        address to,
+        string memory _tokenURI,
+        uint256 eventId,
+        uint256 maxPrice
+        ) public onlyRole(ORGANIZER_ROLE) {
+        uint256 tokenId = tokenIdCounter;
+        tokenIdCounter++;
 
-    _safeMint(to, tokenId);
-    _setTokenURI(tokenId, _tokenURI);
+        _safeMint(to, tokenId);
+        _setTokenURI(tokenId, _tokenURI);
 
-    tokenEventId[tokenId] = eventId;
+        tokenEventId[tokenId] = eventId;
 
-    if (maxPrice > 0) {
-        maxResalePrice[tokenId] = maxPrice;
+        if (maxPrice > 0) {
+            maxResalePrice[tokenId] = maxPrice;
+        }
+
+        emit TicketMinted(tokenId, eventId, to, _tokenURI);
     }
 
-    emit TicketMinted(tokenId, eventId, to, _tokenURI);
-}
+    function batchMint(
+        address[] memory recipients,
+        string[] memory tokenURIs,
+        uint256[] memory maxPrices,
+        uint256 eventId
+        ) public onlyRole(ORGANIZER_ROLE) {
+        require(recipients.length > 0, "Must mint at least one ticket");
+        require(recipients.length <= 100, "Batch size cannot exceed 100");
+        require(
+            recipients.length == tokenURIs.length && 
+            recipients.length == maxPrices.length,
+            "Array lengths must match"
+        );
+
+        for (uint256 i = 0; i < recipients.length; i++) {
+            uint256 tokenId = tokenIdCounter;
+            tokenIdCounter++;
+
+            _safeMint(recipients[i], tokenId);
+            _setTokenURI(tokenId, tokenURIs[i]);
+
+            tokenEventId[tokenId] = eventId;
+
+            if (maxPrices[i] > 0) {
+                maxResalePrice[tokenId] = maxPrices[i];
+            }
+
+            emit TicketMinted(tokenId, eventId, recipients[i], tokenURIs[i]);
+        }
+    }
 
     function checkInTicket(uint256 tokenId) public {
         require(

--- a/packages/contracts/test/BatchMint.test.ts
+++ b/packages/contracts/test/BatchMint.test.ts
@@ -1,0 +1,95 @@
+import { expect } from "chai";
+import { ethers, upgrades } from "hardhat";
+
+describe("TicketNFT - Batch Minting", function () {
+    let ticketNFT: any;
+    let admin: any, organizer: any, hacker: any, user1: any, user2: any, user3: any;
+
+    beforeEach(async function () {
+        [admin, organizer, hacker, user1, user2, user3] = await ethers.getSigners();
+        const TicketNFTFactory = await ethers.getContractFactory("TicketNFT");
+        ticketNFT = await upgrades.deployProxy(TicketNFTFactory, [admin.address], { kind: "uups" });
+
+        const ORGANIZER_ROLE = await ticketNFT.ORGANIZER_ROLE();
+        await ticketNFT.grantRole(ORGANIZER_ROLE, organizer.address);
+    });
+
+    it("Should successfully batch mint multiple tickets", async function () {
+        const recipients = [user1.address, user2.address, user3.address];
+        const tokenURIs = ["ipfs://uri1", "ipfs://uri2", "ipfs://uri3"];
+        const maxPrices = [0, 0, 0];
+
+        await ticketNFT.connect(organizer).batchMint(recipients, tokenURIs, maxPrices, 1);
+
+        expect(await ticketNFT.ownerOf(0)).to.equal(user1.address);
+        expect(await ticketNFT.ownerOf(1)).to.equal(user2.address);
+        expect(await ticketNFT.ownerOf(2)).to.equal(user3.address);
+    });
+
+    it("Should emit TicketMinted event for each token in batch", async function () {
+        const recipients = [user1.address, user2.address];
+        const tokenURIs = ["ipfs://uri1", "ipfs://uri2"];
+        const maxPrices = [0, 0];
+
+        await expect(ticketNFT.connect(organizer).batchMint(recipients, tokenURIs, maxPrices, 1))
+            .to.emit(ticketNFT, "TicketMinted").withArgs(0, 1, user1.address, "ipfs://uri1")
+            .and.to.emit(ticketNFT, "TicketMinted").withArgs(1, 1, user2.address, "ipfs://uri2");
+    });
+
+    it("Should correctly assign tokenURI and eventId for all minted tokens", async function () {
+        const recipients = [user1.address, user2.address];
+        const tokenURIs = ["ipfs://uri1", "ipfs://uri2"];
+        const maxPrices = [0, 0];
+
+        await ticketNFT.connect(organizer).batchMint(recipients, tokenURIs, maxPrices, 5);
+
+        expect(await ticketNFT.tokenURI(0)).to.equal("ipfs://uri1");
+        expect(await ticketNFT.tokenURI(1)).to.equal("ipfs://uri2");
+        expect(await ticketNFT.tokenEventId(0)).to.equal(5);
+        expect(await ticketNFT.tokenEventId(1)).to.equal(5);
+    });
+
+    it("Should correctly set max resale prices per token", async function () {
+        const recipients = [user1.address, user2.address];
+        const tokenURIs = ["ipfs://uri1", "ipfs://uri2"];
+        const maxPrices = [100, 0];
+
+        await ticketNFT.connect(organizer).batchMint(recipients, tokenURIs, maxPrices, 1);
+
+        expect(await ticketNFT.maxResalePrice(0)).to.equal(100);
+        expect(await ticketNFT.maxResalePrice(1)).to.equal(0);
+    });
+
+    it("Should revert if hacker tries to batch mint", async function () {
+        await expect(
+            ticketNFT.connect(hacker).batchMint([user1.address], ["ipfs://uri1"], [0], 1)
+        ).to.be.revertedWithCustomError(ticketNFT, "AccessControlUnauthorizedAccount");
+    });
+
+    it("Should revert if array lengths do not match", async function () {
+        await expect(
+            ticketNFT.connect(organizer).batchMint(
+                [user1.address, user2.address],
+                ["ipfs://uri1"],
+                [0, 0],
+                1
+            )
+        ).to.be.revertedWith("Array lengths must match");
+    });
+
+    it("Should revert if batch size is zero", async function () {
+        await expect(
+            ticketNFT.connect(organizer).batchMint([], [], [], 1)
+        ).to.be.revertedWith("Must mint at least one ticket");
+    });
+
+    it("Should revert if batch size exceeds 100", async function () {
+        const recipients = Array(101).fill(user1.address);
+        const tokenURIs = Array(101).fill("ipfs://uri");
+        const maxPrices = Array(101).fill(0);
+
+        await expect(
+            ticketNFT.connect(organizer).batchMint(recipients, tokenURIs, maxPrices, 1)
+        ).to.be.revertedWith("Batch size cannot exceed 100");
+    });
+});


### PR DESCRIPTION
Closes #69

Implements batch minting on top of the existing `mintTicket()` flow, allowing organizers to mint multiple tickets in a single transaction.

**Batch Mint Function (#70, #71, #72, #73)**
`batchMint()` accepts arrays of recipients, IPFS metadata URIs, and max resale prices alongside a single `eventId` — all tickets in a batch belong to the same event. Follows the same `onlyRole(ORGANIZER_ROLE)` access control as single mint. Input validation reverts early if arrays are mismatched in length, empty, or exceed the 100 ticket cap. Token ID counter increments correctly across the loop ensuring no duplicate IDs.

**Tests (#74, #75)**
8 tests added in `BatchMint.test.ts` covering successful batch minting, correct ownership and metadata assignment per token, event emission for each minted token, max resale price assignment, and all failing scenarios including unauthorized access, mismatched arrays, empty batch, and exceeding the size cap.

**Design decisions:**
* Batch size capped at 100 per transaction — no hard protocol limit exists but this prevents gas limit issues on large batches.
* Transaction reverts entirely if any input validation fails — partial minting is not allowed to prevent permanently broken NFTs.