### PR TITLE
feat: implement whitelist mechanism and presale logic (Issue #7)

### DIFF
--- a/packages/contracts/contracts/TicketNFT.sol
+++ b/packages/contracts/contracts/TicketNFT.sol
@@ -20,6 +20,7 @@ contract TicketNFT is
     uint256 private tokenIdCounter;
     mapping(uint256 => bool) public isUsed;
     mapping(uint256 => mapping(address => bool)) private _whitelist;
+    mapping(uint256 => bool) public presaleActive;
     uint256 public royaltyPercentage;
     string public baseTokenURI;
     mapping(uint256 => uint256) public maxResalePrice;
@@ -28,6 +29,8 @@ contract TicketNFT is
     // Events
     event TicketMinted(uint256 indexed tokenId, uint256 indexed eventId, address indexed to, string tokenURI);
     event TicketCheckedIn(uint256 indexed tokenId, address indexed scanner);
+    event WhitelistUpdated(uint256 indexed eventId, address indexed wallet, bool status);
+    event PresaleStatusUpdated(uint256 indexed eventId, bool active);
 
     // Roles
     bytes32 public constant ORGANIZER_ROLE = keccak256("ORGANIZER_ROLE");
@@ -60,7 +63,10 @@ contract TicketNFT is
         string memory _tokenURI,
         uint256 eventId,
         uint256 maxPrice
-        ) public onlyRole(ORGANIZER_ROLE) {
+        ) public onlyRole(ORGANIZER_ROLE) {  
+        if (presaleActive[eventId]) {
+            require(_whitelist[eventId][to], "Address not whitelisted for presale");
+        }
         uint256 tokenId = tokenIdCounter;
         tokenIdCounter++;
 
@@ -90,6 +96,11 @@ contract TicketNFT is
             "Array lengths must match"
         );
 
+        if (presaleActive[eventId]) {
+            for (uint256 i = 0; i < recipients.length; i++) {
+                require(_whitelist[eventId][recipients[i]], "Address not whitelisted for presale");
+            }
+        }
         for (uint256 i = 0; i < recipients.length; i++) {
             uint256 tokenId = tokenIdCounter;
             tokenIdCounter++;
@@ -124,6 +135,44 @@ contract TicketNFT is
 
     function isValidTicket(uint256 tokenId) public view returns (bool) {
         return _ownerOf(tokenId) != address(0) && !isUsed[tokenId];
+    }
+
+    function setPresaleActive(uint256 eventId, bool active) 
+        public onlyRole(ORGANIZER_ROLE) 
+    {
+        presaleActive[eventId] = active;
+        emit PresaleStatusUpdated(eventId, active);
+    }
+
+    function addToWhitelist(uint256 eventId, address wallet) 
+        public onlyRole(ORGANIZER_ROLE) 
+    {
+        _whitelist[eventId][wallet] = true;
+        emit WhitelistUpdated(eventId, wallet, true);
+    }
+
+    function batchAddToWhitelist(uint256 eventId, address[] memory wallets)
+        public onlyRole(ORGANIZER_ROLE)
+    {   
+        require(wallets.length > 0, "Must provide at least one address");
+        require(wallets.length <= 100, "Batch size cannot exceed 100");
+        for (uint256 i = 0; i < wallets.length; i++) {
+            _whitelist[eventId][wallets[i]] = true;
+            emit WhitelistUpdated(eventId, wallets[i], true);
+        }
+    }
+
+    function removeFromWhitelist(uint256 eventId, address wallet) 
+        public onlyRole(ORGANIZER_ROLE) 
+    {
+        _whitelist[eventId][wallet] = false;
+        emit WhitelistUpdated(eventId, wallet, false);
+    }
+
+    function isWhitelisted(uint256 eventId, address wallet) 
+        public view returns (bool) 
+    {
+        return _whitelist[eventId][wallet];
     }
 
     // Overrides functions

--- a/packages/contracts/test/Whitelist.test.ts
+++ b/packages/contracts/test/Whitelist.test.ts
@@ -1,0 +1,114 @@
+import { expect } from "chai";
+import { ethers, upgrades } from "hardhat";
+
+describe("TicketNFT - Whitelist Mechanism", function () {
+    let ticketNFT: any;
+    let admin: any, organizer: any, hacker: any, whitelisted: any, notWhitelisted: any;
+
+    beforeEach(async function () {
+        [admin, organizer, hacker, whitelisted, notWhitelisted] = await ethers.getSigners();
+        const TicketNFTFactory = await ethers.getContractFactory("TicketNFT");
+        ticketNFT = await upgrades.deployProxy(TicketNFTFactory, [admin.address], { kind: "uups" });
+
+        const ORGANIZER_ROLE = await ticketNFT.ORGANIZER_ROLE();
+        await ticketNFT.grantRole(ORGANIZER_ROLE, organizer.address);
+    });
+
+    it("Should allow organizer to add and remove from whitelist", async function () {
+        await ticketNFT.connect(organizer).addToWhitelist(1, whitelisted.address);
+        expect(await ticketNFT.isWhitelisted(1, whitelisted.address)).to.be.true;
+
+        await ticketNFT.connect(organizer).removeFromWhitelist(1, whitelisted.address);
+        expect(await ticketNFT.isWhitelisted(1, whitelisted.address)).to.be.false;
+    });
+
+    it("Should allow organizer to batch add to whitelist", async function () {
+        const wallets = [whitelisted.address, notWhitelisted.address];
+        await ticketNFT.connect(organizer).batchAddToWhitelist(1, wallets);
+
+        expect(await ticketNFT.isWhitelisted(1, whitelisted.address)).to.be.true;
+        expect(await ticketNFT.isWhitelisted(1, notWhitelisted.address)).to.be.true;
+    });
+
+    it("Should reject hacker from modifying whitelist", async function () {
+        await expect(
+            ticketNFT.connect(hacker).addToWhitelist(1, whitelisted.address)
+        ).to.be.revertedWithCustomError(ticketNFT, "AccessControlUnauthorizedAccount");
+    });
+
+    it("Should allow whitelisted address to mint during presale", async function () {
+        await ticketNFT.connect(organizer).addToWhitelist(1, whitelisted.address);
+        await ticketNFT.connect(organizer).setPresaleActive(1, true);
+
+        await expect(
+            ticketNFT.connect(organizer).mintTicket(whitelisted.address, "ipfs://test", 1, 0)
+        ).to.not.be.reverted;
+    });
+
+    it("Should reject non-whitelisted address during presale", async function () {
+        await ticketNFT.connect(organizer).setPresaleActive(1, true);
+
+        await expect(
+            ticketNFT.connect(organizer).mintTicket(notWhitelisted.address, "ipfs://test", 1, 0)
+        ).to.be.revertedWith("Address not whitelisted for presale");
+    });
+
+    it("Should allow anyone to mint during public sale", async function () {
+        await ticketNFT.connect(organizer).setPresaleActive(1, false);
+
+        await expect(
+            ticketNFT.connect(organizer).mintTicket(notWhitelisted.address, "ipfs://test", 1, 0)
+        ).to.not.be.reverted;
+    });
+
+    it("Should emit WhitelistUpdated event", async function () {
+        await expect(ticketNFT.connect(organizer).addToWhitelist(1, whitelisted.address))
+            .to.emit(ticketNFT, "WhitelistUpdated")
+            .withArgs(1, whitelisted.address, true);
+    });
+
+    it("Should emit PresaleStatusUpdated event", async function () {
+        await expect(ticketNFT.connect(organizer).setPresaleActive(1, true))
+            .to.emit(ticketNFT, "PresaleStatusUpdated")
+            .withArgs(1, true);
+    });
+
+    it("Should revert batch whitelist if empty", async function () {
+        await expect(
+            ticketNFT.connect(organizer).batchAddToWhitelist(1, [])
+        ).to.be.revertedWith("Must provide at least one address");
+    });
+
+    it("Should revert batch whitelist if exceeds 100", async function () {
+        const wallets = Array(101).fill(whitelisted.address);
+        await expect(
+            ticketNFT.connect(organizer).batchAddToWhitelist(1, wallets)
+        ).to.be.revertedWith("Batch size cannot exceed 100");
+    });
+
+    it("Should reject non-whitelisted address in batch mint during presale", async function () {
+        await ticketNFT.connect(organizer).addToWhitelist(1, whitelisted.address);
+        await ticketNFT.connect(organizer).setPresaleActive(1, true);
+
+        await expect(
+            ticketNFT.connect(organizer).batchMint(
+                [whitelisted.address, notWhitelisted.address],
+                ["ipfs://uri1", "ipfs://uri2"],
+                [0, 0],
+                1
+            )
+        ).to.be.revertedWith("Address not whitelisted for presale");
+    });
+
+    it("Should transition correctly from presale to public sale", async function () {
+        await ticketNFT.connect(organizer).setPresaleActive(1, true);
+        await expect(
+            ticketNFT.connect(organizer).mintTicket(notWhitelisted.address, "ipfs://test", 1, 0)
+        ).to.be.revertedWith("Address not whitelisted for presale");
+
+        await ticketNFT.connect(organizer).setPresaleActive(1, false);
+        await expect(
+            ticketNFT.connect(organizer).mintTicket(notWhitelisted.address, "ipfs://test", 1, 0)
+        ).to.not.be.reverted;
+    });
+});


### PR DESCRIPTION
Closes #7

Implements whitelist functionality and presale logic for restricted early ticket sales.

**What's added (#30, #31, #32, #33, #34, #138)**
- `addToWhitelist()`, `removeFromWhitelist()`, and `batchAddToWhitelist()` restricted to `ORGANIZER_ROLE`
- `setPresaleActive()` to toggle presale mode per event
- `isWhitelisted()` public view function for frontend/scanner queries
- Presale enforcement in both `mintTicket()` and `batchMint()` — validation runs before any state changes
- `WhitelistUpdated` and `PresaleStatusUpdated` events for backend listener
- 12 tests covering all scenarios including presale enforcement, public sale transition, batch operations, and edge cases

**Design decisions:**
- Whitelist is per event so each event manages its own presale list independently
- Batch whitelist capped at 100 to match batch mint limit