### PR TITLE
feat: implement resale rules, royalties and platform resell flow (Issue #6)

### DIFF
--- a/packages/contracts/contracts/MockUSDC.sol
+++ b/packages/contracts/contracts/MockUSDC.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockUSDC is ERC20 {
+    constructor() ERC20("Mock USDC", "USDC") {
+        _mint(msg.sender, 1000000 * 10 ** decimals());
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/packages/contracts/contracts/TicketNFT.sol
+++ b/packages/contracts/contracts/TicketNFT.sol
@@ -7,6 +7,8 @@ import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol"
 import "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 
 contract TicketNFT is 
     Initializable, 
@@ -14,23 +16,28 @@ contract TicketNFT is
     ERC721URIStorageUpgradeable,
     AccessControlUpgradeable, 
     ERC2981Upgradeable, 
-    UUPSUpgradeable 
+    UUPSUpgradeable,
+    ReentrancyGuardUpgradeable
 {
     // State variables
     uint256 private tokenIdCounter;
     mapping(uint256 => bool) public isUsed;
     mapping(uint256 => mapping(address => bool)) private _whitelist;
     mapping(uint256 => bool) public presaleActive;
-    uint256 public royaltyPercentage;
+    mapping(uint256 => uint256)public royaltyPercentage;
     string public baseTokenURI;
     mapping(uint256 => uint256) public maxResalePrice;
     mapping(uint256 => uint256) public tokenEventId;
+    mapping(uint256 => address) public eventOrganizer;
+    address public usdcToken;
 
     // Events
     event TicketMinted(uint256 indexed tokenId, uint256 indexed eventId, address indexed to, string tokenURI);
     event TicketCheckedIn(uint256 indexed tokenId, address indexed scanner);
     event WhitelistUpdated(uint256 indexed eventId, address indexed wallet, bool status);
     event PresaleStatusUpdated(uint256 indexed eventId, bool active);
+    event EventRoyaltyUpdated(uint256 indexed eventId, uint256 basisPoints);
+    event TicketResold(uint256 indexed tokenId, address indexed from, address indexed to, uint256 price);
 
     // Roles
     bytes32 public constant ORGANIZER_ROLE = keccak256("ORGANIZER_ROLE");
@@ -43,13 +50,16 @@ contract TicketNFT is
     }
 
     // Initializer function to set up the contract
-    function initialize(address defaultAdmin) public initializer {
+    function initialize(address defaultAdmin, address _usdcToken) public initializer {
         __ERC721_init("NFTicketPass", "NFTP");
         __ERC721URIStorage_init();
         __AccessControl_init();
         __ERC2981_init();
+        __ReentrancyGuard_init();
 
         _grantRole(DEFAULT_ADMIN_ROLE, defaultAdmin);
+        usdcToken = _usdcToken;
+
     }
 
     function _authorizeUpgrade(address newImplementation)
@@ -74,6 +84,10 @@ contract TicketNFT is
         _setTokenURI(tokenId, _tokenURI);
 
         tokenEventId[tokenId] = eventId;
+    
+        if(eventOrganizer[eventId] == address(0)) {
+            eventOrganizer[eventId] = msg.sender;
+        }
 
         if (maxPrice > 0) {
             maxResalePrice[tokenId] = maxPrice;
@@ -100,6 +114,10 @@ contract TicketNFT is
             for (uint256 i = 0; i < recipients.length; i++) {
                 require(_whitelist[eventId][recipients[i]], "Address not whitelisted for presale");
             }
+        }
+
+        if (eventOrganizer[eventId] == address(0)) {
+            eventOrganizer[eventId] = msg.sender;
         }
         for (uint256 i = 0; i < recipients.length; i++) {
             uint256 tokenId = tokenIdCounter;
@@ -173,6 +191,52 @@ contract TicketNFT is
         public view returns (bool) 
     {
         return _whitelist[eventId][wallet];
+    }
+
+    function setRoyaltyPercentage(uint256 eventId, uint256 basisPoints) 
+        public onlyRole(DEFAULT_ADMIN_ROLE) 
+    {
+        require(basisPoints <= 10000, "Basis points must be less than or equal to 10000");
+        royaltyPercentage[eventId] = basisPoints;
+        emit EventRoyaltyUpdated(eventId, basisPoints);
+    }
+
+    function royaltyInfo(uint256 tokenId, uint256 salePrice)
+        public view override returns (address receiver, uint256 amount)
+    {
+        uint256 eventId = tokenEventId[tokenId];
+        uint256 royalty = (salePrice * royaltyPercentage[eventId]) / 10000;
+        return (eventOrganizer[eventId], royalty);
+    }
+
+    function resell(uint256 tokenId, address buyer, uint256 salePrice) public nonReentrant {
+        require(ownerOf(tokenId) == msg.sender, "You do not own this ticket");
+        require(!isUsed[tokenId], "Cannot resell a used ticket");
+        require(buyer != address(0), "Invalid buyer address");
+
+        if (maxResalePrice[tokenId] > 0) {
+            require(salePrice <= maxResalePrice[tokenId], "Sale price exceeds maximum resale price");
+        }
+
+        IERC20 usdc = IERC20(usdcToken);
+
+        require(
+            usdc.transferFrom(buyer, address(this), salePrice),
+            "USDC transfer from buyer failed"
+        );
+
+        (address royaltyReceiver, uint256 royaltyAmount) = royaltyInfo(tokenId, salePrice);
+        uint256 sellerAmount = salePrice - royaltyAmount;
+
+        if (royaltyAmount > 0) {
+            require(usdc.transfer(royaltyReceiver, royaltyAmount), "Royalty transfer failed");
+        }
+
+        require(usdc.transfer(msg.sender, sellerAmount), "Seller transfer failed");
+
+        _transfer(msg.sender, buyer, tokenId);
+
+        emit TicketResold(tokenId, msg.sender, buyer, salePrice);
     }
 
     // Overrides functions

--- a/packages/contracts/scripts/deploy.ts
+++ b/packages/contracts/scripts/deploy.ts
@@ -7,8 +7,7 @@ async function main() {
     const TicketNFT = await ethers.getContractFactory("TicketNFT");
     
     const contract = await upgrades.deployProxy(TicketNFT, [deployer.address], {
-        initializer: "initialize",
-        unsafeAllow: ["constructor"],
+        initializer: "initialize"
     });
 
     await contract.waitForDeployment();

--- a/packages/contracts/scripts/test-mint.ts
+++ b/packages/contracts/scripts/test-mint.ts
@@ -5,8 +5,7 @@ async function main() {
 
     const TicketNFT = await ethers.getContractFactory("TicketNFT");
     const contract = await upgrades.deployProxy(TicketNFT, [deployer.address], {
-        initializer: "initialize",
-        unsafeAllow: ["constructor"],
+        initializer: "initialize"
     });
     await contract.waitForDeployment();
 

--- a/packages/contracts/test/Resale.test.ts
+++ b/packages/contracts/test/Resale.test.ts
@@ -1,0 +1,130 @@
+import { expect } from "chai";
+import { ethers, upgrades } from "hardhat";
+
+describe("TicketNFT - Resale Rules & Royalties", function () {
+    let ticketNFT: any;
+    let mockUSDC: any;
+    let admin: any, organizer: any, seller: any, buyer: any, hacker: any;
+
+    beforeEach(async function () {
+        [admin, organizer, seller, buyer, hacker] = await ethers.getSigners();
+
+        const MockUSDC = await ethers.getContractFactory("MockUSDC");
+        mockUSDC = await MockUSDC.deploy();
+
+        const TicketNFTFactory = await ethers.getContractFactory("TicketNFT");
+        ticketNFT = await upgrades.deployProxy(
+            TicketNFTFactory,
+            [admin.address, await mockUSDC.getAddress()],
+            { kind: "uups" }
+        );
+
+        const ORGANIZER_ROLE = await ticketNFT.ORGANIZER_ROLE();
+        await ticketNFT.grantRole(ORGANIZER_ROLE, organizer.address);
+
+        await mockUSDC.mint(buyer.address, ethers.parseUnits("1000", 6));
+
+        await ticketNFT.connect(organizer).mintTicket(
+            seller.address,
+            "ipfs://test",
+            1,
+            ethers.parseUnits("200", 6)
+        );
+    });
+
+    it("Should successfully resell a ticket", async function () {
+        const salePrice = ethers.parseUnits("100", 6);
+
+        await mockUSDC.connect(buyer).approve(await ticketNFT.getAddress(), salePrice);
+        await ticketNFT.connect(seller).resell(0, buyer.address, salePrice);
+
+        expect(await ticketNFT.ownerOf(0)).to.equal(buyer.address);
+    });
+
+    it("Should pay royalty to organizer and remainder to seller", async function () {
+        const salePrice = ethers.parseUnits("100", 6);
+        const royaltyBps = 1000;
+
+        await ticketNFT.connect(admin).setRoyaltyPercentage(1, royaltyBps);
+
+        const sellerBalanceBefore = await mockUSDC.balanceOf(seller.address);
+        const organizerBalanceBefore = await mockUSDC.balanceOf(organizer.address);
+
+        await mockUSDC.connect(buyer).approve(await ticketNFT.getAddress(), salePrice);
+        await ticketNFT.connect(seller).resell(0, buyer.address, salePrice);
+
+        const expectedRoyalty = salePrice * BigInt(royaltyBps) / BigInt(10000);
+        const expectedSellerAmount = salePrice - expectedRoyalty;
+
+        expect(await mockUSDC.balanceOf(seller.address)).to.equal(sellerBalanceBefore + expectedSellerAmount);
+        expect(await mockUSDC.balanceOf(organizer.address)).to.equal(organizerBalanceBefore + expectedRoyalty);
+    });
+
+    it("Should revert if sale price exceeds max resale price", async function () {
+        const salePrice = ethers.parseUnits("300", 6);
+
+        await mockUSDC.connect(buyer).approve(await ticketNFT.getAddress(), salePrice);
+
+        await expect(
+            ticketNFT.connect(seller).resell(0, buyer.address, salePrice)
+        ).to.be.revertedWith("Sale price exceeds maximum resale price");
+    });
+
+    it("Should revert if caller does not own the ticket", async function () {
+        const salePrice = ethers.parseUnits("100", 6);
+
+        await mockUSDC.connect(buyer).approve(await ticketNFT.getAddress(), salePrice);
+
+        await expect(
+            ticketNFT.connect(hacker).resell(0, buyer.address, salePrice)
+        ).to.be.revertedWith("You do not own this ticket");
+    });
+
+    it("Should revert if ticket is already used", async function () {
+        const salePrice = ethers.parseUnits("100", 6);
+
+        await ticketNFT.connect(organizer).checkInTicket(0);
+
+        await mockUSDC.connect(buyer).approve(await ticketNFT.getAddress(), salePrice);
+
+        await expect(
+            ticketNFT.connect(seller).resell(0, buyer.address, salePrice)
+        ).to.be.revertedWith("Cannot resell a used ticket");
+    });
+
+    it("Should revert if buyer address is zero", async function () {
+        const salePrice = ethers.parseUnits("100", 6);
+
+        await mockUSDC.connect(buyer).approve(await ticketNFT.getAddress(), salePrice);
+
+        await expect(
+            ticketNFT.connect(seller).resell(0, ethers.ZeroAddress, salePrice)
+        ).to.be.revertedWith("Invalid buyer address");
+    });
+
+    it("Should emit TicketResold event", async function () {
+        const salePrice = ethers.parseUnits("100", 6);
+
+        await mockUSDC.connect(buyer).approve(await ticketNFT.getAddress(), salePrice);
+
+        await expect(ticketNFT.connect(seller).resell(0, buyer.address, salePrice))
+            .to.emit(ticketNFT, "TicketResold")
+            .withArgs(0, seller.address, buyer.address, salePrice);
+    });
+
+    it("Should allow resell with no price cap set", async function () {
+        await ticketNFT.connect(organizer).mintTicket(
+            seller.address,
+            "ipfs://test2",
+            1,
+            0
+        );
+
+        const salePrice = ethers.parseUnits("999", 6);
+        await mockUSDC.connect(buyer).approve(await ticketNFT.getAddress(), salePrice);
+
+        await expect(
+            ticketNFT.connect(seller).resell(1, buyer.address, salePrice)
+        ).to.not.be.reverted;
+    });
+});


### PR DESCRIPTION
Closes #6

Implements EIP-2981 royalties, per-event royalty configuration, and a platform resell flow with price cap enforcement.

**Royalties (#25, #26, #27, #66)**
`setRoyaltyPercentage()` allows admin to configure royalties per event in basis points. `royaltyInfo()` overrides EIP-2981 and returns the event organizer as royalty receiver with the calculated amount. `eventOrganizer` mapping is set on first mint per event and used as the royalty recipient.

**Resale Flow (#28, #67)**
`resell()` is a platform-level resale function that enforces the price cap, handles USDC payment splitting between organizer (royalty) and seller (remainder), and transfers the NFT to the buyer in a single atomic transaction. Protected by `nonReentrant`. Off-platform transfers remain unrestricted per client direction — price cap enforcement only applies within the platform resell flow.

**OpenSea Compatibility (#29)**
Full ERC-721 + EIP-2981 compatibility maintained. `supportsInterface()` correctly declares all standards.

**USDC Integration**
`ReentrancyGuardUpgradeable` added. `usdcToken` address stored as state variable and set at initialization. `MockUSDC.sol` added for local testing.

**Tests**
8 tests in `Resale.test.ts` covering successful resell, royalty payout calculation, price cap enforcement, non-owner resell rejection, used ticket rejection, invalid buyer address, event emission, and resell with no price cap set.

**Design decisions:**
* Price cap enforcement is platform-only — off-platform transfers via standard `transferFrom()` cannot be restricted without breaking OpenSea compatibility. This is per client feedback.
* `eventOrganizer` is set outside the minting loop in `batchMint` for gas efficiency — only needs to be set once per event.
* Royalty receiver is the organizer who first minted tickets for that event, stored on-chain via `eventOrganizer` mapping.